### PR TITLE
Controller::createUrl changed to Url::toRoute

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -10,6 +10,7 @@ namespace mihaildev\elfinder;
 
 use Yii;
 use yii\helpers\Json;
+use yii\helpers\Url;
 use yii\web\Controller as BaseController;
 use yii\web\JsExpression;
 use yii\web\NotFoundHttpException;
@@ -74,7 +75,7 @@ class Controller extends BaseController{
             throw new NotFoundHttpException;
 
         $options = [
-            'url'=> $this->createUrl('connect'),
+            'url'=> Url::toRoute('connect'),
             'customData' => [
                 Yii::$app->request->csrfParam => Yii::$app->request->csrfToken
             ],


### PR DESCRIPTION
refering to https://github.com/yiisoft/yii2/pull/2676

from yii2 removed:
yii\web\Controller::createUrl
yii\web\Controller::createAbsoluteUrl

now use:
yii\helpers\Url::toRoute
