### PR TITLE
Fixed bug in method ElFinder::genPathHash()

### DIFF
--- a/ElFinder.php
+++ b/ElFinder.php
@@ -50,7 +50,7 @@ class ElFinder extends BaseWidjet{
 			$volume = 1;
 		}
 		$hash = rtrim(strtr(base64_encode($path), '+/=', '-_.'), '.');
-		return 'elf_l' . $volume .'_' . $hash;
+		return 'elf_fls' . $volume .'_' . $hash;
 	}
 
 	public static function getManagerUrl($controller, $params = [])


### PR DESCRIPTION
Не работает [startPath](https://github.com/MihailDev/yii2-elfinder/blob/master/ElFinder.php#L73) из-за этого бага.
То ли это опечатка, то ли намеренно сделано, но volume написан неверно.

https://github.com/MihailDev/yii2-elfinder/blob/master/ElFinder.php#L53