### PR TITLE
php 7.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "psr-4": {"mihaildev\\elfinder\\": ""}
     },
     "require": {
+        "yiisoft/yii2": "~2.0.13",
         "yiisoft/yii2-jui": "*",
         "studio-42/elfinder": "^2.1.10"
     },

--- a/volume/Base.php
+++ b/volume/Base.php
@@ -7,7 +7,7 @@
 namespace mihaildev\elfinder\volume;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 use yii\helpers\FileHelper;
 
@@ -15,7 +15,7 @@ use yii\helpers\FileHelper;
 /**
  * @property array defaults
  */
-class Base extends Object{
+class Base extends BaseObject{
 
 	public $driver = 'LocalFileSystem';
 


### PR DESCRIPTION
* Use `yii\base\BaseObject` instead of `yii\base\Object`
* Yii2 minimum version set to 2.0.13, due to absence of `yii\base\BaseObject` in previous versions.