### PR TITLE
Change MD5 to SHA256 hash for improved security

### DIFF
--- a/volume/Base.php
+++ b/volume/Base.php
@@ -127,7 +127,7 @@ class Base extends BaseObject
 			$options['tmbPath'] = Yii::getAlias('@webroot/' . $this->tmbPath);
 			$options['tmbURL'] = Yii::$app->request->hostInfo . Yii::getAlias('@web/'.$this->tmbPath);
 		}else{
-			$subPath = md5($this->className() . '|' . serialize($this->name));
+			$subPath = hash('sha256', $this->className().'|'.serialize($this->name));
 			$options['tmbPath'] = Yii::$app->assetManager->getPublishedPath(__DIR__) . DIRECTORY_SEPARATOR . $subPath;
 			$options['tmbURL'] = Yii::$app->request->hostInfo . Yii::$app->assetManager->getPublishedUrl(__DIR__) . '/' . $subPath;
 		}


### PR DESCRIPTION
## Summary
Replace MD5 hash function with SHA256 for better security practices.

## Changes
- Updated `volume/Base.php` to use `hash('sha256', ...)` instead of `md5(...)`
- This affects the thumbnail path generation logic

## Motivation
MD5 is considered cryptographically broken and unsuitable for further use. SHA256 provides better security and collision resistance.

## Testing
- [ ] Verify thumbnail generation still works correctly
- [ ] Ensure no breaking changes to existing functionality