### PR TITLE
Add CSP nonce support for inline CSS registration

### DIFF
--- a/views/manager.php
+++ b/views/manager.php
@@ -17,6 +17,10 @@ if(!empty($options['noConflict']))
 unset($options['noConflict']);
 $options['soundPath'] = Assets::getSoundPathUrl();
 
+$cssOptions = [];
+if (isset($options['nonce']) && $options['nonce'] != null) {
+    $cssOptions['nonce'] = $options['nonce'];
+}
 
 $this->registerJs("
 function ElFinderGetCommands(disabled){
@@ -66,7 +70,7 @@ html, body {
     position: relative;
     padding: 0; margin: 0;
 }
-");
+", $cssOptions);
 
 
 


### PR DESCRIPTION
## Summary
Add Content Security Policy (CSP) nonce support to the elFinder manager view for better security compliance.

## Changes
- **`views/manager.php`**: Add CSP nonce support for inline CSS registration

## Implementation
- Add `$cssOptions` array to handle nonce attributes
- Conditional check for `$options['nonce']` parameter 
- Pass `$cssOptions` to `registerCss()` method when nonce is provided

## Usage
```php
$options['nonce'] = 'your-csp-nonce-value';